### PR TITLE
[subscriptions start date] 

### DIFF
--- a/includes/Errors/SubscriptionErrorCode.php
+++ b/includes/Errors/SubscriptionErrorCode.php
@@ -11,4 +11,5 @@ class SubscriptionErrorCode extends ApiErrors\ErrorCode
     const API_SUBSCRIPTION_CANCELLATION_FAILED = 'Razorpay API subscription cancellation failed';
     const API_PLAN_CREATION_FAILED             = 'Razorpay API plan creation failed';
     const API_CUSTOMER_CREATION_FAILED         = 'Razorpay API customer creation failed';
+    const SUBSCRIPTION_START_DATE_INVALID      = 'Invalid subscription start date specified';
 }

--- a/includes/razorpay-subscription-webhook.php
+++ b/includes/razorpay-subscription-webhook.php
@@ -19,9 +19,15 @@ class RZP_Subscription_Webhook extends RZP_Webhook
      */
 
     /**
+     * @var WC_Razorpay
+     */
+    protected $razorpay;
+
+    /**
      * Processes a payment authorized webhook
      *
      * @param array $data
+     * @return string|void
      */
     protected function paymentAuthorized(array $data)
     {
@@ -35,7 +41,7 @@ class RZP_Subscription_Webhook extends RZP_Webhook
         {
             $invoiceId = $data['payload']['payment']['entity']['invoice_id'];
 
-            $subscriptionId = $this->getSubscriptionId($invoiceId);
+            $subscriptionId = $this->getSubscriptionId($invoiceId, $data['event']);
 
             // Process subscription this way
             if (empty($subscriptionId) === false)
@@ -48,7 +54,8 @@ class RZP_Subscription_Webhook extends RZP_Webhook
     /**
      * Currently we handle only subscription failures using this webhook
      *
-     * @param $data
+     * @param array $data
+     * @return string|void
      */
     protected function paymentFailed(array $data)
     {
@@ -58,7 +65,7 @@ class RZP_Subscription_Webhook extends RZP_Webhook
         {
             $invoiceId = $data['payload']['payment']['entity']['invoice_id'];
 
-            $subscriptionId = $this->getSubscriptionId($invoiceId);
+            $subscriptionId = $this->getSubscriptionId($invoiceId, $data['event']);
 
             // Process subscription this way
             if (empty($subscriptionId) === false)
@@ -68,18 +75,20 @@ class RZP_Subscription_Webhook extends RZP_Webhook
         }
     }
 
-    protected function getSubscriptionId($invoiceId)
+    protected function getSubscriptionId($invoiceId, $event)
     {
+        $api = $this->razorpay->getRazorpayApiInstance();
+
         try
         {
-            $invoice = $this->api->invoice->fetch($invoiceId);
+            $invoice = $api->invoice->fetch($invoiceId);
         }
         catch (Exception $e)
         {
             $log = array(
-                'message'   => $e->getMessage(),
-                'data'      => $invoiceId,
-                'event'     => $data['event']
+                'message' => $e->getMessage(),
+                'data'    => $invoiceId,
+                'event'   => $event
             );
 
             error_log(json_encode($log));

--- a/includes/razorpay-subscription-webhook.php
+++ b/includes/razorpay-subscription-webhook.php
@@ -55,7 +55,7 @@ class RZP_Subscription_Webhook extends RZP_Webhook
      * Currently we handle only subscription failures using this webhook
      *
      * @param array $data
-     * @return string|void
+     * @return string|null
      */
     protected function paymentFailed(array $data)
     {

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -7,20 +7,6 @@ use Razorpay\Woocommerce\Errors as WooErrors;
 class RZP_Subscriptions
 {
     /**
-     * Razorpay API Key Secret
-     *
-     * @var string
-     */
-    protected $keyId;
-
-    /**
-     * Razorpay API Key ID
-     *
-     * @var string
-     */
-    protected $keySecret;
-
-    /**
      * @var Api
      */
     protected $api;
@@ -36,9 +22,9 @@ class RZP_Subscriptions
 
     public function __construct($keyId, $keySecret)
     {
-        $this->api = new Api($keyId, $keySecret);
+        $this->setRazorpayApiInstance($keyId, $keySecret);
 
-        $this->razorpay = new WC_Razorpay(false);
+        $this->setRazorpayInstance();
     }
 
     public function createSubscription($orderId)
@@ -410,8 +396,13 @@ class RZP_Subscriptions
         return self::RAZORPAY_SUBSCRIPTION_ID . $orderId;
     }
 
-    protected function getRazorpayApiInstance()
+    protected function setRazorpayApiInstance($keyId, $keySecret)
     {
-        return new Api($this->keyId, $this->keySecret);
+        $this->api = new Api($keyId, $keySecret);
+    }
+
+    protected function setRazorpayInstance()
+    {
+        $this->razorpay = new WC_Razorpay(false);
     }
 }

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -159,14 +159,18 @@ class RZP_Subscriptions
             //
             $startDay = $metadata['razorpay_wc_start_date'][0];
 
-            $oneMonthAhead = date('Y-m-d', strtotime('+1 month'));
+            $interval = WC_Subscriptions_Product::get_interval($product['product_id']);
 
-            $oneMonthAheadArray = explode('-', $oneMonthAhead);
+            $period = WC_Subscriptions_Product::get_period($product['product_id']);
 
-            $oneMonthAheadArray[2] = $startDay;
+            $oneIntervalAhead = date('Y-m-d', strtotime("+$interval $period"));
+
+            $oneIntervalAheadArray = explode('-', $oneIntervalAhead);
+
+            $oneIntervalAheadArray[2] = $startDay;
 
             // 5:30 AM on the date configured as metadata
-            $startDate = strtotime(implode('-', $oneMonthAheadArray));
+            $startDate = strtotime(implode('-', $oneIntervalAheadArray));
 
             $recurringFee = WC_Subscriptions_Product::get_price($product['product_id']);
 

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -178,7 +178,11 @@ class RZP_Subscriptions
 
             $subscriptionData['start_at'] = $startDate;
 
-            // TODO: Since start date is actually second recurring, end date needs to be 1 period before time
+            //
+            // In the case where we take the first recurring payment as a up front amount, and the
+            // second recurring payment as the first recurring payment, we reduce the total count by 1
+            //
+            $subscriptionData['total_count'] = $subscriptionData['total_count'] - 1;
         }
     }
 

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -6,8 +6,29 @@ use Razorpay\Woocommerce\Errors as WooErrors;
 
 class RZP_Subscriptions
 {
-    protected $razorpay;
+    /**
+     * Razorpay API Key Secret
+     *
+     * @var string
+     */
+    protected $keyId;
+
+    /**
+     * Razorpay API Key ID
+     *
+     * @var string
+     */
+    protected $keySecret;
+
+    /**
+     * @var Api
+     */
     protected $api;
+
+    /**
+     * @var WC_Razorpay
+     */
+    protected $razorpay;
 
     const RAZORPAY_SUBSCRIPTION_ID       = 'razorpay_subscription_id';
     const RAZORPAY_PLAN_ID               = 'razorpay_wc_plan_id';
@@ -53,7 +74,7 @@ class RZP_Subscriptions
     {
         try
         {
-            $subscription = $this->api->subscription->cancel($subscriptionId);
+            $this->api->subscription->cancel($subscriptionId);
         }
         catch (Exception $e)
         {
@@ -77,8 +98,6 @@ class RZP_Subscriptions
     protected function getSubscriptionCreateData($orderId)
     {
         $order = new WC_Order($orderId);
-
-        $sub = $this->getWooCommerceSubscriptionFromOrderId($orderId);
 
         $product = $this->getProductFromOrder($order);
 
@@ -126,8 +145,6 @@ class RZP_Subscriptions
 
     protected function getProductPlanId($product, $order)
     {
-        $currency = get_woocommerce_currency();
-
         $productId = $product['product_id'];
 
         $metadata = get_post_meta($productId);
@@ -152,11 +169,10 @@ class RZP_Subscriptions
      * Takes in product metadata and product
      * Creates or gets created plan
      *
-     * @param $metadata,
+     * @param $metadata
      * @param $product
-     *
-     * @return string $planId
-     * @return bool $created
+     * @param $order
+     * @return array
      */
     protected function createOrGetPlanId($metadata, $product, $order)
     {
@@ -223,9 +239,7 @@ class RZP_Subscriptions
 
     protected function getPlanArguments($product, $order)
     {
-        $sub = $this->getWooCommerceSubscriptionFromOrderId($order->get_id());
-
-        $productId    = $product['product_id'];
+        $sub          = $this->getWooCommerceSubscriptionFromOrderId($order->get_id());
 
         $period       = $sub->get_billing_period();
 

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -110,7 +110,7 @@ class RZP_Subscriptions
         $signUpFee = WC_Subscriptions_Product::get_sign_up_fee($product['product_id']);
 
         // TODO: Refactor if needed
-        $this->setStartAtIfNeeded($subscriptionData, $signUpFee, $product);
+        $this->setStartAtIfNeeded($subscriptionData, $signUpFee, $order);
 
         // We add the signup fee as an addon
         if ($signUpFee)
@@ -132,8 +132,12 @@ class RZP_Subscriptions
         return $subscriptionData;
     }
 
-    protected function setStartAtIfNeeded(& $subscriptionData, & $signUpFee, $product)
+    protected function setStartAtIfNeeded(& $subscriptionData, & $signUpFee, $order)
     {
+        $product = $this->getProductFromOrder($order);
+
+        $sub = $this->getWooCommerceSubscriptionFromOrderId($order->get_id());
+
         $metadata = get_post_meta($product['product_id']);
 
         if (empty($metadata['razorpay_wc_start_date']) === false)
@@ -145,9 +149,9 @@ class RZP_Subscriptions
             //
             $startDay = $metadata['razorpay_wc_start_date'][0];
 
-            $interval = WC_Subscriptions_Product::get_interval($product['product_id']);
+            $period       = $sub->get_billing_period();
 
-            $period = WC_Subscriptions_Product::get_period($product['product_id']);
+            $interval     = $sub->get_billing_interval();
 
             $oneIntervalAhead = date('Y-m-d', strtotime("+$interval $period"));
 
@@ -158,7 +162,7 @@ class RZP_Subscriptions
             // 5:30 AM on the date configured as metadata
             $startDate = strtotime(implode('-', $oneIntervalAheadArray));
 
-            $recurringFee = WC_Subscriptions_Product::get_price($product['product_id']);
+            $recurringFee = $sub->get_total();
 
             $signUpFee += $recurringFee;
 

--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -189,7 +189,7 @@ class RZP_Subscriptions
 
         $interval = $sub->get_billing_interval();
 
-        $date = new DateTime('now', new DateTimeZone('Asia/Kolkata'));
+        $date = new DateTime('now');
 
         //
         // We get the date one interval ahead from the current date. The interval depends

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -72,12 +72,6 @@ function woocommerce_razorpay_subscriptions_init()
         );
 
         /**
-         * Icon URL, set in constructor
-         * @var string
-         */
-        public $icon;
-
-        /**
          * Instance of the class RZP_subscriptions found in __DIR__ . 'includes/razorpay-subscriptions'
          * It is used to make all subscriptions related API calls to the Razorpay's API
          * @var RZP_Subscriptions

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -83,7 +83,7 @@ function woocommerce_razorpay_subscriptions_init()
          * @var RZP_Subscriptions
          */
         protected $subscriptions;
-
+        
         public function __construct()
         {
             parent::__construct();

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 Plugin Name: Razorpay Subscriptions for WooCommerce
 Plugin URI: https://razorpay.com
@@ -15,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) )
 }
 
 define('RAZORPAY_WOOCOMMERCE_PLUGIN', 'woo-razorpay');
+
 $pluginRoot = WP_PLUGIN_DIR . '/' . RAZORPAY_WOOCOMMERCE_PLUGIN;
 
 require_once $pluginRoot . '/razorpay-payments.php';
@@ -25,7 +27,6 @@ require_once __DIR__ . '/includes/razorpay-subscriptions.php';
 
 use Razorpay\Api\Api;
 use Razorpay\Api\Errors;
-use Razorpay\Woocommerce\Errors as WooErrors;
 
 // Load this after the woo-razorpay plugin
 add_action('plugins_loaded', 'woocommerce_razorpay_subscriptions_init', 20);
@@ -40,19 +41,36 @@ function woocommerce_razorpay_subscriptions_init()
 
     class WC_Razorpay_Subscription extends WC_Razorpay
     {
+        /**
+         * Unique ID for the gateway
+         * @var string
+         */
         public $id = 'razorpay_subscriptions';
+
+        /**
+         * Title of the payment method shown on the admin page.
+         * @var string
+         */
         public $method_title = 'Razorpay Subscriptions';
 
         const RAZORPAY_SUBSCRIPTION_ID       = 'razorpay_subscription_id';
         const DEFAULT_LABEL                  = 'MasterCard/Visa Credit Card';
         const DEFAULT_DESCRIPTION            = 'Setup automatic recurring billing on a MasterCard or Visa Credit Card';
 
+        /**
+         * Settings visible to the user
+         * @var array
+         */
         protected $visibleSettings = array(
             'enabled',
             'title',
             'description',
         );
 
+        /**
+         * Contains all supported methods of woocommerce subscriptions
+         * @var array
+         */
         public $supports = array(
             'subscriptions',
             'subscription_reactivation',
@@ -60,11 +78,18 @@ function woocommerce_razorpay_subscriptions_init()
             'subscription_cancellation',
         );
 
+        /**
+         * Instance of helper class located in __DIR__ . 'includes/razorpay-subscriptions'
+         * @var RZP_Subscriptions
+         */
+        protected $subscriptions;
+
         public function __construct()
         {
             parent::__construct();
-            $this->icon =  plugins_url('images/logo.png' , __FILE__);
+
             $this->mergeSettingsWithParentPlugin();
+
             $this->setupExtraHooks();
         }
 
@@ -72,7 +97,7 @@ function woocommerce_razorpay_subscriptions_init()
         {
             // Easiest way to read config of a different plugin
             // is to initialize it
-            $gw = new WC_Razorpay(false);
+            $wcRazorpay = new WC_Razorpay(false);
 
             $parentSettings = array(
                 'key_id',
@@ -82,7 +107,7 @@ function woocommerce_razorpay_subscriptions_init()
 
             foreach ($parentSettings as $key)
             {
-                $this->settings[$key] = $gw->settings[$key];
+                $this->settings[$key] = $wcRazorpay->settings[$key];
             }
         }
 
@@ -96,8 +121,6 @@ function woocommerce_razorpay_subscriptions_init()
 
         public function disable_non_subscription($availableGateways)
         {
-            global $woocommerce;
-
             $enable = WC_Subscriptions_Cart::cart_contains_subscription();
 
             if ($enable === false)
@@ -145,19 +168,20 @@ function woocommerce_razorpay_subscriptions_init()
             }
 
             return [
-                'recurring'         => 1,
-                'subscription_id'   => $subscriptionId,
+                'recurring'       => 1,
+                'subscription_id' => $subscriptionId,
             ];
         }
 
         public function init_form_fields()
         {
             parent::init_form_fields();
-            $this->fields = $this->form_fields;
 
-            unset($this->fields['payment_action']);
+            $fields = $this->form_fields;
 
-            $this->form_fields = $this->fields;
+            unset($fields['payment_action']);
+
+            $this->form_fields = $fields;
         }
 
         protected function getDisplayAmount($order)

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -25,9 +25,6 @@ require_once __DIR__ . '/includes/razorpay-subscription-webhook.php';
 require_once __DIR__ . '/includes/Errors/SubscriptionErrorCode.php';
 require_once __DIR__ . '/includes/razorpay-subscriptions.php';
 
-use Razorpay\Api\Api;
-use Razorpay\Api\Errors;
-
 // Load this after the woo-razorpay plugin
 add_action('plugins_loaded', 'woocommerce_razorpay_subscriptions_init', 20);
 add_action('admin_post_nopriv_rzp_wc_webhook', 'razorpay_webhook_subscription_init', 20);
@@ -53,12 +50,8 @@ function woocommerce_razorpay_subscriptions_init()
          */
         public $method_title = 'Razorpay Subscriptions';
 
-        const RAZORPAY_SUBSCRIPTION_ID       = 'razorpay_subscription_id';
-        const DEFAULT_LABEL                  = 'MasterCard/Visa Credit Card';
-        const DEFAULT_DESCRIPTION            = 'Setup automatic recurring billing on a MasterCard or Visa Credit Card';
-
         /**
-         * Settings visible to the user
+         * This array controls what settings are visible to the user
          * @var array
          */
         protected $visibleSettings = array(
@@ -79,11 +72,16 @@ function woocommerce_razorpay_subscriptions_init()
         );
 
         /**
-         * Instance of helper class located in __DIR__ . 'includes/razorpay-subscriptions'
+         * Instance of the class RZP_subscriptions found in __DIR__ . 'includes/razorpay-subscriptions'
+         * It is used to make all subscriptions related API calls to the Razorpay's API
          * @var RZP_Subscriptions
          */
         protected $subscriptions;
-        
+
+        const RAZORPAY_SUBSCRIPTION_ID       = 'razorpay_subscription_id';
+        const DEFAULT_LABEL                  = 'MasterCard/Visa Credit Card';
+        const DEFAULT_DESCRIPTION            = 'Setup automatic recurring billing on a MasterCard or Visa Credit Card';
+
         public function __construct()
         {
             parent::__construct();
@@ -198,8 +196,8 @@ function woocommerce_razorpay_subscriptions_init()
             $sessionKey = $this->getSubscriptionSessionKey($orderId);
 
             $attributes = array(
-                self::RAZORPAY_PAYMENT_ID       => $_POST['razorpay_payment_id'],
-                self::RAZORPAY_SIGNATURE        => $_POST['razorpay_signature'],
+                self::RAZORPAY_PAYMENT_ID       => $_POST[self::RAZORPAY_PAYMENT_ID],
+                self::RAZORPAY_SIGNATURE        => $_POST[self::RAZORPAY_SIGNATURE],
                 self::RAZORPAY_SUBSCRIPTION_ID  => $woocommerce->session->get($sessionKey),
             );
 

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -72,6 +72,12 @@ function woocommerce_razorpay_subscriptions_init()
         );
 
         /**
+         * Icon URL, set in constructor
+         * @var string
+         */
+        public $icon;
+
+        /**
          * Instance of the class RZP_subscriptions found in __DIR__ . 'includes/razorpay-subscriptions'
          * It is used to make all subscriptions related API calls to the Razorpay's API
          * @var RZP_Subscriptions
@@ -85,6 +91,8 @@ function woocommerce_razorpay_subscriptions_init()
         public function __construct()
         {
             parent::__construct();
+
+            $this->icon = plugins_url('images/logo.png', __FILE__);
 
             $this->mergeSettingsWithParentPlugin();
 


### PR DESCRIPTION
- [x] Minor bug fix around method `getSubscriptionId` in `RZP_Subscription_Webhook`
- [x] Adding feature to save start date of the month (`razorpay_wc_start_date`) as product metadata
- [x] Initial payment will be sent across as add on in this case