### PR TITLE
Initialise new field custom order creation message

### DIFF
--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -111,6 +111,7 @@ function woocommerce_razorpay_subscriptions_init()
                 'key_id',
                 'key_secret',
                 'webhook_secret',
+                'order_success_message',
             );
 
             foreach ($parentSettings as $key)


### PR DESCRIPTION
In razorpay woocommerce We have added a new field order_success_message
This should be added to settings 