### PR TITLE
fix bug of upfront payment and razorpay include sdk

### DIFF
--- a/includes/razorpay-subscriptions.php
+++ b/includes/razorpay-subscriptions.php
@@ -104,6 +104,13 @@ class RZP_Subscriptions
 
         $length = (int) WC_Subscriptions_Product::get_length($product['product_id']);
 
+        //Subscription will not work in case of never expire case.
+
+        if ($length == 0)
+        {
+            throw new Exception('Perpetual subscriptions are not supported.');
+        }
+
         //The first payment is always set as an upfront amount to support woocommerce discounts like fixed
         // cart discounts which is only for the first payment.
 
@@ -126,11 +133,6 @@ class RZP_Subscriptions
         if ($signUpFee)
         {
             $subscriptionData['addons'] = array(array('item' => $this->getUpfrontAmount($signUpFee, $order, $product)));
-        }
-
-        if ($length ==1)
-        {
-            return $subscriptionData;
         }
 
         $trial_length     = WC_Subscriptions_Product::get_trial_length( $product['product_id'] );

--- a/razorpay-subscriptions.php
+++ b/razorpay-subscriptions.php
@@ -24,7 +24,7 @@ if ( ! is_dir( $pluginRoot ) )
     return;
 }
 
-require_once $pluginRoot . '/razorpay-payments.php';
+require_once $pluginRoot . '/woo-razorpay.php';
 require_once $pluginRoot . '/razorpay-sdk/Razorpay.php';
 require_once __DIR__ . '/includes/razorpay-subscription-webhook.php';
 require_once __DIR__ . '/includes/Errors/SubscriptionErrorCode.php';


### PR DESCRIPTION
- Resolve bug in case of upfront payment is charge then subscription state is active.

- Handled upfront payment in case of user selected sign up fees for only one time subscription.

- Fixes for include woo-razorpay sdk.